### PR TITLE
feat: navigation that won't take up a ton of space as we add more exercises

### DIFF
--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -1,22 +1,80 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 const Nav: React.FC = () => {
+  const [showExercises, setShowExercises] = useState(false);
+  const collapseSymbol = showExercises ? <IconUpCaret /> : <IconDownCaret />;
+
   return (
     <nav>
-      <ul>
-        <li>
+      <List>
+        <ListItem>
           <Link to="/">Home</Link>
-        </li>
-        <li>
-          <Link to="/exercise-0">Exercise 0</Link>
-        </li>
-        <li>
-          <Link to="/exercise-1">Exercise 1</Link>
-        </li>
-      </ul>
+        </ListItem>
+        <ListItem>
+          <a href="#" onClick={() => setShowExercises(!showExercises)}>
+            Exercises {collapseSymbol}
+          </a>
+        </ListItem>
+      </List>
+      {showExercises && <SubNav />}
     </nav>
   );
 };
 
+const SubNav: React.FC = () => {
+  return (
+    <List>
+      <ListItem>
+        <Link to="/exercise-0">Exercise 0</Link>
+      </ListItem>
+      <ListItem>
+        <Link to="/exercise-1">Exercise 1</Link>
+      </ListItem>
+    </List>
+  );
+};
+
+const List: React.FC = ({ children }) => {
+  return <ul style={{ display: 'flex', padding: '0' }}>{children}</ul>;
+};
+
+const ListItem: React.FC = ({ children }) => {
+  return (
+    <li style={{ listStyleType: 'none', marginRight: '20px' }}>{children}</li>
+  );
+};
+
+const IconDownCaret: React.FC = () => {
+  return (
+    <Icon>
+      <path d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"></path>
+    </Icon>
+  );
+};
+
+const IconUpCaret: React.FC = () => {
+  return (
+    <Icon>
+      <path d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"></path>
+    </Icon>
+  );
+};
+
+const Icon: React.FC = ({ children }) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 1024 1024"
+      height="1em"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ display: 'inline-block', verticalAlign: 'middle' }}
+    >
+      {children}
+    </svg>
+  );
+};
 export default Nav;

--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -66,7 +66,7 @@ const Icon: React.FC = ({ children }) => {
     <svg
       stroke="currentColor"
       fill="currentColor"
-      stroke-width="0"
+      strokeWidth="0"
       viewBox="0 0 1024 1024"
       height="1em"
       width="1em"


### PR DESCRIPTION
This is a "make space for upcoming work" type of PR. As I was starting exercise 2 on fragment containers, I decided it was time to improve the nav so that it doesn't keep getting bigger as we add exercises.

This is a very-very-simple implementation of a drop-down menu for the exercises. No frills. It's not pretty, but it prevents links to exercises from taking over the top of the screen.

https://user-images.githubusercontent.com/1627089/112214309-0d34b480-8bed-11eb-9774-99e7be43b810.mp4


## Implementation

There are _a few_ inline styles added -- my intention all along has been to avoid styling of any sorts because it potentially adds another thing for people to learn, but I don't think the few styles I added here will get in the way. Most people won't even  notice them, as they aren't in any of the exercises. 

SVG icons were borrowed from https://react-icons.github.io/react-icons/search?q=aifillcaret. 