### PR TITLE
chore: Smooth some edges in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,32 @@
-# relay-workshop
+# Relay Learning Exercises
 
-Home for Artsy's [Relay](https://relay.dev/docs/v10.1.3/) peer learning tutorial.
+[Relay](https://relay.dev/docs/v10.1.3/) is a powerful GraphQL client. At Artsy we use it in both our [web app](https://github.com/artsy/force) and [mobile app](https://github.com/artsy/eigen). 
 
-## Why?
-
-Relay is a powerful GraphQL client, but it's complex and difficult to learn. These exercises aim to ease your learning by introducing Relay concepts a little bit at a time. 
+Relay is also complex and difficult to learn. This project contains exercises to help you learn Relay[*](#which-version-of-relay-are-we-learning) by introducing concepts a little bit at a time. 
 
 ## Get Started
 
 1. Clone this repo. 
 2. Install dependencies: `yarn install`. 
+3. Confirm that everything installed: if the command `yarn relay` fails, something's not right. Reach out in Artsy's #dev-help Slack channel if you're an Artsy employee, or [create an issue](https://github.com/artsy/relay-workshop/issues/new) if you're not.
 
 ## The Exercises
 
-Each folder under `src/exercises` has a README.md containing instructions. Read and follow them! Any time you see 
+Each folder under `src/exercises` has a README.md containing instructions. Read and follow them!
+
+Any time you see a laptop emoji (💻), you're going to edit code or run a command. 
 
 Start with [exercise 0 on the Relay compiler](./src/exercises/00-Relay-Compiler/README.md)! 
 
-For support, there is a `completed` folder inside each exercise. If you get stuck, check there to see the code in the completed state. 
+For support, there is a `completed` folder inside each exercise. If you get stuck, check there to see the code in the completed state for the exercise.
 
 ## FAQ
-### Why is this using an older version of Relay?
+### Which version of Relay are we learning?
 
-These exercises have been built in support of new engineers at Artsy; thus it is based on code that looks like ours. Relay recently released version 11, including hooks, but neither [Artsy's web app](https://github.com/artsy/force) and [mobile app](https://github.com/artsy/eigen) are running it yet. 
+These exercises are for [Relay Modern](https://relay.dev/docs/v10.1.3/new-in-relay-modern/), version 10. 
+
+### Why aren't we learning the most recent version of Relay?
+
+These exercises have been built in support of new engineers at Artsy; thus they are based on code that looks like ours. Relay recently released version 11, including hooks, but neither [Artsy's web app](https://github.com/artsy/force) nor [mobile app](https://github.com/artsy/eigen) are running it yet. 
+
+When our codebase is updated to use a newer version of Relay, we'll update these exercises as well.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Relay](https://relay.dev/docs/v10.1.3/) is a powerful GraphQL client. At Artsy we use it in both our [web app](https://github.com/artsy/force) and [mobile app](https://github.com/artsy/eigen). 
 
-Relay is also complex and difficult to learn. This project contains exercises to help you learn Relay[*](#which-version-of-relay-are-we-learning) by introducing concepts a little bit at a time. 
+Relay is also complex and difficult to learn - but it's totally worth it! This project contains exercises to help you learn Relay[*](#which-version-of-relay-are-we-learning) by introducing concepts a little bit at a time. 
 
 ## Get Started
 

--- a/src/exercises/03-Infrastructure/README.md
+++ b/src/exercises/03-Infrastructure/README.md
@@ -1,4 +1,8 @@
-# Infrastructure - Store, Network Layer, Environment
+# Coming soon!
+
+This exercise is in progress. 
+
+## Infrastructure - Store, Network Layer, Environment
 
 - Doesn't have to be HTTP
 - We probably don't need as much hands-on here - this is a lot of theory & abstraction but we rarely (if ever) touch this stuff.

--- a/src/exercises/99-Whats-Next/README.md
+++ b/src/exercises/99-Whats-Next/README.md
@@ -1,0 +1,12 @@
+# What's next?
+
+If you finished all the existing exercises, congrats! This is tough stuff, and hopefully you've got a better idea of how to work with Relay. 
+
+We're working on more exercises, including but probably not limited to: 
+
+- Relay infrastructure
+- Pagination
+- Mutating data
+- Testing
+
+Until then, dive into the code for Artsy's [web app](https://github.com/artsy/force) and [mobile app](https://github.com/artsy/eigen) to see more Relay in use.


### PR DESCRIPTION
Addresses #21.

Includes a few things, to remove any big gaps between what's in my head and what learners will experience.

1. Revises the intro to add context about what we're learning, and why
2. Makes it obvious that exercise 3 on infrastructure is just an outline at this point
3. Adds a doc describing what's next, to add some closure when they get to the end. 


Reviewers: I'd especially love feedback on whether you think the intro doc (README.md at the root) gives enough context to get people into the exercises, or if there is more needed. 