### PR TITLE
Updates to ReadMe for Exercises 1 and 2. 

### DIFF
--- a/src/exercises/01-Query-Renderer/README.md
+++ b/src/exercises/01-Query-Renderer/README.md
@@ -170,7 +170,7 @@ The `render` prop is a function that will be called to render the child componen
 ```
 _./Artist1.tsx_
 
-After saving, you should finally see artist info on the artist page! 
+After saving, you should finally see artist info on the artist page! If you see a type error, read on! We are about to address it.
 
 ![Artist page with hardcoded artist ID](./docs/3-hardcoded-artist-id.png)
 

--- a/src/exercises/02-Fragment-Container/README.md
+++ b/src/exercises/02-Fragment-Container/README.md
@@ -83,7 +83,7 @@ export const Artist2: React.FC<Artist2Props> = ({ artist }) => {
 
 Each of these section components emits some data from the `artist` prop passed in. 
 
-This style of component isolation is a is a common and powerful way to build a React app. Each component includes all the markup, styles, and interaction logic it needs. This is great for reusability, and even greater for comprehensibility.
+This style of component isolation is a common and powerful way to build a React app. Each component includes all the markup, styles, and interaction logic it needs. This is great for reusability, and even greater for comprehensibility.
 
 One thing is missing from each of these components though — a specification of the data it needs to render properly. That's currently handled entirely in the [`Artist2QueryRenderer`](./Artist2QueryRenderer.tsx), where _all_ fields for _all_ components are aggregated: 
 


### PR DESCRIPTION
This is to update Exercises 1 and 2 of the Relay-Workshop.

This just adds some additional clarification regarding type errors. Also went and removed a typo of repeated text.