### PR TITLE
Add context to specs & a TODO.md

### DIFF
--- a/src/exercises/03-Testing-Queries/Artist3Heading.spec.tsx
+++ b/src/exercises/03-Testing-Queries/Artist3Heading.spec.tsx
@@ -10,53 +10,59 @@ import {
 } from "./Artist3Heading"
 import { Artist3HeadingTestQuery } from "./__generated__/Artist3HeadingTestQuery.graphql"
 
-it("Artist3Heading (silly)", () => {
-  const props: Artist3HeadingProps = {
-    artist: {
-      name: "Andy Warhol",
-      birthYear: 123,
-      " $refType": "Artist3Heading_artist",
-    },
-  }
+describe("Artist3Heading", () => {
+  describe("as an isolated component", () => {
+    it("renders the values we give it", () => {
+      const props: Artist3HeadingProps = {
+        artist: {
+          name: "Andy Warhol",
+          birthYear: 123,
+          " $refType": "Artist3Heading_artist",
+        },
+      }
 
-  const { queryAllByText } = render(<Artist3Heading {...props} />)
+      const { queryAllByText } = render(<Artist3Heading {...props} />)
 
-  const header = queryAllByText("Andy Warhol")
-  expect(header).toHaveLength(1)
-})
-
-it("Artist3Heading", () => {
-  const mockEnvironment = createMockEnvironment()
-
-  const { queryAllByText } = render(
-    <QueryRenderer<Artist3HeadingTestQuery>
-      environment={mockEnvironment}
-      query={graphql`
-        query Artist3HeadingTestQuery($artistID: ID!) {
-          artist(id: $artistID) {
-            ...Artist3Heading_artist
-          }
-        }
-      `}
-      variables={{ artistID: "wow" }}
-      render={({ props }) => {
-        if (!props || !props.artist) {
-          return <div>Loading</div>
-        }
-        return <Artist3HeadingFragmentContainer artist={props.artist} />
-      }}
-    />
-  )
-
-  mockEnvironment.mock.resolveMostRecentOperation(operation =>
-    MockPayloadGenerator.generate(operation, {
-      Artist: () => ({
-        name: "Andy Warhol",
-        birthYear: 123,
-      }),
+      const header = queryAllByText("Andy Warhol")
+      expect(header).toHaveLength(1)
     })
-  )
+  })
 
-  const header = queryAllByText("Andy Warhol")
-  expect(header).toHaveLength(1)
+  describe("as a Relay fragmentContainer", () => {
+    it("renders the values from the Relay query", () => {
+      const mockEnvironment = createMockEnvironment()
+
+      const { queryAllByText } = render(
+        <QueryRenderer<Artist3HeadingTestQuery>
+          environment={mockEnvironment}
+          query={graphql`
+            query Artist3HeadingTestQuery($artistID: ID!) {
+              artist(id: $artistID) {
+                ...Artist3Heading_artist
+              }
+            }
+          `}
+          variables={{ artistID: "wow" }}
+          render={({ props }) => {
+            if (!props || !props.artist) {
+              return <div>Loading</div>
+            }
+            return <Artist3HeadingFragmentContainer artist={props.artist} />
+          }}
+        />
+      )
+
+      mockEnvironment.mock.resolveMostRecentOperation(operation =>
+        MockPayloadGenerator.generate(operation, {
+          Artist: () => ({
+            name: "Andy Warhol",
+            birthYear: 123,
+          }),
+        })
+      )
+
+      const header = queryAllByText("Andy Warhol")
+      expect(header).toHaveLength(1)
+    })
+  })
 })

--- a/src/exercises/03-Testing-Queries/completed/Artist3Heading.spec.tsx
+++ b/src/exercises/03-Testing-Queries/completed/Artist3Heading.spec.tsx
@@ -10,53 +10,59 @@
 // } from "./Artist3Heading"
 // import { Artist3HeadingTestQuery } from "./__generated__/Artist3HeadingTestQuery.graphql"
 
-// it("Artist3Heading (silly)", () => {
-//   const props: Artist3HeadingProps = {
-//     artist: {
-//       name: "Andy Warhol",
-//       birthYear: 123,
-//       " $refType": "Artist3Heading_artist",
-//     },
-//   }
+// describe("Artist3Heading", () => {
+//   describe("as an isolated component", () => {
+//     it("renders the values we give it", () => {
+//       const props: Artist3HeadingProps = {
+//         artist: {
+//           name: "Andy Warhol",
+//           birthYear: 123,
+//           " $refType": "Artist3Heading_artist",
+//         },
+//       }
 
-//   const { queryAllByText } = render(<Artist3Heading {...props} />)
+//       const { queryAllByText } = render(<Artist3Heading {...props} />)
 
-//   const header = queryAllByText("Andy Warhol")
-//   expect(header).toHaveLength(1)
-// })
-
-// it("Artist3Heading", () => {
-//   const mockEnvironment = createMockEnvironment()
-
-//   const { queryAllByText } = render(
-//     <QueryRenderer<Artist3HeadingTestQuery>
-//       environment={mockEnvironment}
-//       query={graphql`
-//         query Artist3HeadingTestQuery($artistID: ID!) {
-//           artist(id: $artistID) {
-//             ...Artist3Heading_artist
-//           }
-//         }
-//       `}
-//       variables={{ artistID: "wow" }}
-//       render={({ props }) => {
-//         if (!props || !props.artist) {
-//           return <div>Loading</div>
-//         }
-//         return <Artist3HeadingFragmentContainer artist={props.artist} />
-//       }}
-//     />
-//   )
-
-//   mockEnvironment.mock.resolveMostRecentOperation(operation =>
-//     MockPayloadGenerator.generate(operation, {
-//       Artist: () => ({
-//         name: "Andy Warhol",
-//         birthYear: 123,
-//       }),
+//       const header = queryAllByText("Andy Warhol")
+//       expect(header).toHaveLength(1)
 //     })
-//   )
+//   })
 
-//   const header = queryAllByText("Andy Warhol")
-//   expect(header).toHaveLength(1)
+//   describe("as a Relay fragmentContainer", () => {
+//     it("renders the values from the Relay query", () => {
+//       const mockEnvironment = createMockEnvironment()
+
+//       const { queryAllByText } = render(
+//         <QueryRenderer<Artist3HeadingTestQuery>
+//           environment={mockEnvironment}
+//           query={graphql`
+//             query Artist3HeadingTestQuery($artistID: ID!) {
+//               artist(id: $artistID) {
+//                 ...Artist3Heading_artist
+//               }
+//             }
+//           `}
+//           variables={{ artistID: "wow" }}
+//           render={({ props }) => {
+//             if (!props || !props.artist) {
+//               return <div>Loading</div>
+//             }
+//             return <Artist3HeadingFragmentContainer artist={props.artist} />
+//           }}
+//         />
+//       )
+
+//       mockEnvironment.mock.resolveMostRecentOperation(operation =>
+//         MockPayloadGenerator.generate(operation, {
+//           Artist: () => ({
+//             name: "Andy Warhol",
+//             birthYear: 123,
+//           }),
+//         })
+//       )
+
+//       const header = queryAllByText("Andy Warhol")
+//       expect(header).toHaveLength(1)
+//     })
+//   })
 // })

--- a/src/exercises/99-Whats-Next/TODO.md
+++ b/src/exercises/99-Whats-Next/TODO.md
@@ -1,0 +1,8 @@
+# Next steps for building these exercises
+
+- [ ] Finish building exercise 3 (testing queries)
+  - [ ] Write instructions
+
+## Futures
+
+- [ ] add a "component integration test" to exercise 3 (test Artist3 component that includes multiple fragments)


### PR DESCRIPTION
A couple small things in this PR, that we paired on a few weeks ago:

1. Some `describe`/`it` names to add more context to the specs we wrote
2. A TODO.md that lays out what's left to build so that others may pick it up