### PR TITLE
feat: fill in intro/setup/orientiation sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start-exercises": "concurrently -n relay,web \"yarn relay --watch\" \"yarn start-web\"",
     "start-web": "parcel src/index.html",
     "test": "jest",
+    "test:watch": "jest --watch",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
@@ -66,7 +67,6 @@
       "pre-commit": "lint-staged"
     }
   },
-
   "lint-staged": {
     "*.*": [
       "yarn prettier-write"

--- a/src/exercises/03-Testing-Queries/Artist3Heading.spec.tsx
+++ b/src/exercises/03-Testing-Queries/Artist3Heading.spec.tsx
@@ -12,57 +12,10 @@ import { Artist3HeadingTestQuery } from "./__generated__/Artist3HeadingTestQuery
 
 describe("Artist3Heading", () => {
   describe("as an isolated component", () => {
-    it("renders the values we give it", () => {
-      const props: Artist3HeadingProps = {
-        artist: {
-          name: "Andy Warhol",
-          birthYear: 123,
-          " $refType": "Artist3Heading_artist",
-        },
-      }
-
-      const { queryAllByText } = render(<Artist3Heading {...props} />)
-
-      const header = queryAllByText("Andy Warhol")
-      expect(header).toHaveLength(1)
-    })
+    it("renders the values we give it", () => {})
   })
 
   describe("as a Relay fragmentContainer", () => {
-    it("renders the values from the Relay query", () => {
-      const mockEnvironment = createMockEnvironment()
-
-      const { queryAllByText } = render(
-        <QueryRenderer<Artist3HeadingTestQuery>
-          environment={mockEnvironment}
-          query={graphql`
-            query Artist3HeadingTestQuery($artistID: ID!) {
-              artist(id: $artistID) {
-                ...Artist3Heading_artist
-              }
-            }
-          `}
-          variables={{ artistID: "wow" }}
-          render={({ props }) => {
-            if (!props || !props.artist) {
-              return <div>Loading</div>
-            }
-            return <Artist3HeadingFragmentContainer artist={props.artist} />
-          }}
-        />
-      )
-
-      mockEnvironment.mock.resolveMostRecentOperation(operation =>
-        MockPayloadGenerator.generate(operation, {
-          Artist: () => ({
-            name: "Andy Warhol",
-            birthYear: 123,
-          }),
-        })
-      )
-
-      const header = queryAllByText("Andy Warhol")
-      expect(header).toHaveLength(1)
-    })
+    it("renders the values from the Relay query", () => {})
   })
 })

--- a/src/exercises/03-Testing-Queries/README.md
+++ b/src/exercises/03-Testing-Queries/README.md
@@ -4,7 +4,7 @@
 
 So far we've built an app that queries data. As good dev citizens, we want to write some tests to make sure our app is displaying what we think it's displaying. This will help us prevent future regressions, as well as document our expectations of the system for future developers.
 
-We are using Jest, `relay-test-utils`, and React Testing Library to write unit tests for our components that use Relay. There are three main modules that we'll use in our tests (we'll go more into these later):
+We are going to use Jest, `relay-test-utils`, and React Testing Library to write unit tests for our components that use Relay. There are three main modules that we'll use in our tests (we'll go more into these later):
 
 - `createMockEnvironment`
 - `MockPayloadGenerator`
@@ -19,19 +19,61 @@ Read more:
 
 Start the tests:
 
-....
+💻 _Run `yarn test:watch` from a console pointed at the root of this project_
+
+This command will run Jest in watch mode, and we'll see our tests re-run as we make changes. If you're unfamiliar with Jest, [here's a nice introduction to its features](https://www.testim.io/blog/jest-testing-a-helpful-introductory-tutorial/).
+
+You should see a message that there are "No tests found related to files changed since last commit.":
+
+```
+No tests found related to files changed since last commit.
+Press `a` to run all tests, or run Jest with `--watchAll`.
+
+Watch Usage
+ › Press a to run all tests.
+ › Press f to run only failed tests.
+ › Press p to filter by a filename regex pattern.
+ › Press t to filter by a test name regex pattern.
+ › Press q to quit watch mode.
+ › Press Enter to trigger a test run.
+```
 
 ### Orient yourself
 
-...
-
 #### Artist3Heading component
 
-...describe what we're going to test about this component...
+We are going to write tests against the Artist3Heading component from the previous exercise, which lives in the Artist3Heading.tsx file. This component renders the artist's name and birth year.
+
+#### Artist3Heading tests
+
+We'll write two tests in this exercise. Both will confirm that the correct information is being rendered by the component, but we'll take two different approaches to the tests: completely isolated from Relay, and integrated with a mocked Relay store.
+
+We've stubbed out a file to hold these tests: Artist3Heading.spec.tsx.
+
+For now, this file contains a single import, and a set of Jest test scenarios stubbed out:
+
+```tsx
+import React from "react"
+
+describe("Artist3Heading", () => {
+  describe("as an isolated component", () => {
+    it("renders the values we give it", () => {})
+  })
+
+  describe("as a Relay fragmentContainer", () => {
+    it("renders the values from the Relay query", () => {})
+  })
+})
+```
+
+_./Artist3Heading.spec.tsx_
+
+We're going to fill in these test scenarios!
 
 ### Test Artist3Heading in isolation
 
-- describe how we're isolating the test to not use Relay
+We'll start with a test of our component in isolation from Relay. We don't do this often at Artsy, but it pops up occasionally that we just want to verify some logic in a component, and we don't really care how Relay plays a part.
+
 - guide them to write the silly test (test #1)
 - guidance: tell them when to use this kind of test, link them to some force examples, etc
 

--- a/src/exercises/03-Testing-Queries/README.md
+++ b/src/exercises/03-Testing-Queries/README.md
@@ -46,7 +46,9 @@ We are going to write tests against the Artist3Heading component from the previo
 
 #### Artist3Heading tests
 
-We'll write two tests in this exercise. Both will confirm that the correct information is being rendered by the component, but we'll take two different approaches to the tests: completely isolated from Relay, and integrated with a mocked Relay store.
+We'll write two tests in this exercise. Both will confirm that the correct information is being rendered by the component, but we'll take two different approaches to the tests:
+1. Completely isolated from Relay
+2. Integrated with a mocked Relay store.
 
 We've stubbed out a file to hold these tests: Artist3Heading.spec.tsx.
 

--- a/src/exercises/03-Testing-Queries/beginning/Artist3Heading.spec.tsx
+++ b/src/exercises/03-Testing-Queries/beginning/Artist3Heading.spec.tsx
@@ -1,0 +1,21 @@
+// import React from "react"
+// import { render } from "@testing-library/react"
+// import { QueryRenderer } from "react-relay"
+// import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
+// import { graphql } from "relay-runtime"
+// import {
+//   Artist3Heading,
+//   Artist3HeadingFragmentContainer,
+//   Artist3HeadingProps,
+// } from "./Artist3Heading"
+// import { Artist3HeadingTestQuery } from "./__generated__/Artist3HeadingTestQuery.graphql"
+
+// describe("Artist3Heading", () => {
+//   describe("as an isolated component", () => {
+//     it("renders the values we give it", () => {})
+//   })
+
+//   describe("as a Relay fragmentContainer", () => {
+//     it("renders the values from the Relay query", () => {})
+//   })
+// })

--- a/src/exercises/03-Testing-Queries/beginning/Artist3Heading.spec.tsx
+++ b/src/exercises/03-Testing-Queries/beginning/Artist3Heading.spec.tsx
@@ -1,14 +1,4 @@
 // import React from "react"
-// import { render } from "@testing-library/react"
-// import { QueryRenderer } from "react-relay"
-// import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
-// import { graphql } from "relay-runtime"
-// import {
-//   Artist3Heading,
-//   Artist3HeadingFragmentContainer,
-//   Artist3HeadingProps,
-// } from "./Artist3Heading"
-// import { Artist3HeadingTestQuery } from "./__generated__/Artist3HeadingTestQuery.graphql"
 
 // describe("Artist3Heading", () => {
 //   describe("as an isolated component", () => {


### PR DESCRIPTION
Adds some details to the Introduction, Setup, and Orientation sections of exercise 3. 

- includes a new npm script for running tests in watch mode
- resets Artist3Heading.spec.tsx to a "starting" point, and preserves that starting point in the "beginning" folder