### PR TITLE
feat: more baby steps on exercise 3

### DIFF
--- a/src/exercises/03-Testing-Queries/Artist3Heading.spec.tsx
+++ b/src/exercises/03-Testing-Queries/Artist3Heading.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import { createMockEnvironment } from "relay-test-utils"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { render } from "@testing-library/react"
 import { Artist3HeadingFragmentContainer } from "./Artist3Heading"
 import { Artist3HeadingTestQuery } from "./__generated__/Artist3HeadingTestQuery.graphql"
@@ -21,14 +21,25 @@ describe("Artist3Heading", () => {
         `}
         variables={{}}
         render={({ props }) => {
-          //   if (!props || !props.artist) {
-          //     return <div>Loading</div>
-          //   }
-          //   return <Artist3HeadingFragmentContainer artist={props.artist} />
-          return <div>fun</div>
+          if (!props || !props.artist) {
+            return <div>Loading</div>
+          }
+          return <Artist3HeadingFragmentContainer artist={props.artist} />
         }}
       />
     )
+
+    mockEnvironment.mock.resolveMostRecentOperation(operation =>
+      MockPayloadGenerator.generate(operation, {
+        Artist: () => ({
+          name: "Andy Warhol",
+          birthYear: 123,
+        }),
+      })
+    )
+
+    const header = root.queryAllByText("Andy Warhol")
+    expect(header).toHaveLength(1)
   })
 })
 

--- a/src/exercises/03-Testing-Queries/completed/Artist3Heading.spec.tsx
+++ b/src/exercises/03-Testing-Queries/completed/Artist3Heading.spec.tsx
@@ -14,7 +14,7 @@
 //   it("renders the values from the Relay query", () => {
 //     const mockEnvironment = createMockEnvironment()
 
-//     const { queryAllByText } = render(
+//     const root = render(
 //       <QueryRenderer<Artist3HeadingTestQuery>
 //         environment={mockEnvironment}
 //         query={graphql`
@@ -43,7 +43,7 @@
 //       })
 //     )
 
-//     const header = queryAllByText("Andy Warhol")
+//     const header = root.queryAllByText("Andy Warhol")
 //     expect(header).toHaveLength(1)
 //   })
 // })


### PR DESCRIPTION
This PR includes work to chip away at exercise 3. It's still incomplete, but the steps to actually write the test are written up. 

I also removed some old notes, and updated the completed spec to avoid having to explain a trivial unnecessary change in the code (switching from accessing query methods on `root` to destructuring them). 

